### PR TITLE
upgraded numpy to version 1.16.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ This assumes, `tbiLsfVirtualEnvDir` is accessible from all compute nodes. Furthe
 module load python/2.7.9
 virtualenv "$tbiLsfVirtualEnvDir"
 source "$tbiLsfVirtualEnvDir/bin/activate"
-# The order of installations may go wrong with Biopython before numpy, which results in an error.
-# Therefore:
-pip install numpy==1.11.3
 pip install -r "$pluginInstallationDir/resources/analysisTools/snvPipeline/environments/requirements.txt
 ```
 

--- a/resources/analysisTools/snvPipeline/environments/requirements.txt
+++ b/resources/analysisTools/snvPipeline/environments/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.11.3
+numpy==1.16.6
 biopython==1.57
 Cython==0.27.3
 funcsigs==1.0.2

--- a/resources/analysisTools/snvPipeline/environments/requirements.txt
+++ b/resources/analysisTools/snvPipeline/environments/requirements.txt
@@ -1,8 +1,8 @@
-numpy==1.16.6
+numpy==1.11.3
 biopython==1.57
 Cython==0.27.3
 funcsigs==1.0.2
-matplotlib==1.4.3
+matplotlib==1.5.3
 mock==2.0.0
 nose==1.3.7
 pbr==3.1.1


### PR DESCRIPTION
matplotlib makes use of numpy's `_multiarray_umath` which became available at numpy version >=1.16.0
numpy at version 1.11.3 will cause errors at import of matplotlib in python scripts

Changes in results after 1.11.3->1.16.6 upgrade have been observed in terms of larger number of decimal places (more precise results). Hence, workflow result files may change but the impact should be negligable for interpretation.